### PR TITLE
Fix minor typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ R packages. If you already have a version of Bioconductor (>=3.3) installed,
 you can do gthe following:
 
 ```
-libary(BiocManager)
+library(BiocManager)
 BiocManager::install("genbankr")
 ```
 


### PR DESCRIPTION
Changed `libary` to `library` so users can copy and run the code to install this package. Thanks for writing this package for us users!